### PR TITLE
Implement gpt‑4o-mini-transcribe

### DIFF
--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -13,7 +13,8 @@ export const config = {
 
   // OpenAI API Configuration (server-side only)
   openai: {
-    realtimeModel: 'gpt-4o-mini-realtime-preview',
+    // Default STT model for real-time transcription
+    realtimeModel: 'gpt-4o-mini-transcribe',
     realtimeEndpoint: 'wss://api.openai.com/v1/realtime'
   },
 

--- a/frontend/src/lib/webrtcTranscription.ts
+++ b/frontend/src/lib/webrtcTranscription.ts
@@ -35,7 +35,8 @@ export class WebRTCTranscriptionService {
 
   constructor(config: WebRTCConfig) {
     this.config = {
-      model: 'gpt-4o-mini-realtime-preview', // Use the supported mini realtime model
+      // Default to the new STT model
+      model: 'gpt-4o-mini-transcribe',
       voiceActivityDetection: true,
       language: 'en',
       ...config
@@ -261,7 +262,8 @@ export class WebRTCTranscriptionService {
         input_audio_format: 'pcm16',
         output_audio_format: 'pcm16',
         input_audio_transcription: {
-          model: 'whisper-1' // Only model officially enabled for transcription_session flow
+          // Use OpenAI's latest STT model
+          model: 'gpt-4o-mini-transcribe'
         },
         turn_detection: this.config.voiceActivityDetection ? {
           type: 'server_vad',

--- a/frontend/tests/lib/webrtc.test.ts
+++ b/frontend/tests/lib/webrtc.test.ts
@@ -132,7 +132,7 @@ describe('WebRTC Transcription', () => {
           input_audio_format: 'pcm16',
           output_audio_format: 'pcm16',
           input_audio_transcription: {
-            model: 'whisper-1'
+            model: 'gpt-4o-mini-transcribe'
           },
           turn_detection: {
             type: 'server_vad',
@@ -287,7 +287,7 @@ describe('WebRTC Transcription', () => {
           input_audio_format: 'pcm16',
           output_audio_format: 'pcm16',
           input_audio_transcription: {
-            model: 'whisper-1'
+            model: 'gpt-4o-mini-transcribe'
           },
           turn_detection: {
             type: 'server_vad',
@@ -306,7 +306,7 @@ describe('WebRTC Transcription', () => {
         expect.stringContaining('"type":"session.update"')
       )
       expect(mockDataChannel.send).toHaveBeenCalledWith(
-        expect.stringContaining('"model":"whisper-1"')
+        expect.stringContaining('"model":"gpt-4o-mini-transcribe"')
       )
     })
 


### PR DESCRIPTION
## Summary
- default to `gpt-4o-mini-transcribe` STT model in config
- update WebRTC transcription service to use the new model
- adjust tests accordingly

## Testing
- `npm test` *(fails: jest not found)*