### PR TITLE
Persist live transcript data to session

### DIFF
--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -468,7 +468,7 @@ export default function App() {
     }
   };
 
-  const handleLiveTranscript = (newTranscriptText: string, speaker: 'ME' | 'THEM') => {
+  const handleLiveTranscript = async (newTranscriptText: string, speaker: 'ME' | 'THEM') => {
     if (newTranscriptText && newTranscriptText.trim().length > 0) {
       const newLine: TranscriptLine = {
         id: Math.random().toString(36).substring(7),
@@ -479,6 +479,30 @@ export default function App() {
       };
       setTranscript(prev => [...prev, newLine]);
       setTalkStats(prev => updateTalkStats(prev, speaker, newTranscriptText));
+
+      if (conversationId) {
+        try {
+          await fetch(`/api/sessions/${conversationId}/transcript`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify([
+              {
+                session_id: conversationId,
+                content: newLine.text,
+                speaker: speaker === 'ME' ? 'me' : 'them',
+                confidence_score: newLine.confidence,
+                start_time_seconds: sessionDuration,
+                is_final: true
+              }
+            ])
+          });
+        } catch (err) {
+          console.error('Failed to save transcript line:', err);
+          setErrorMessage('Failed to save transcript.');
+        }
+      }
       // Auto-guidance removed - use manual button instead
     }
   };

--- a/frontend/src/lib/useIncrementalTimeline.ts
+++ b/frontend/src/lib/useIncrementalTimeline.ts
@@ -99,6 +99,29 @@ export function useIncrementalTimeline({
       setLastUpdated(new Date(data.generatedAt));
       setError(null);
 
+      if (sessionId && data.newEventsCount > 0) {
+        try {
+          await fetch(`/api/sessions/${sessionId}/timeline`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(
+              updatedTimeline
+                .slice(0, data.newEventsCount)
+                .map(event => ({
+                  session_id: sessionId,
+                  event_timestamp: event.timestamp.toISOString(),
+                  title: event.title,
+                  description: event.description,
+                  type: event.type,
+                  importance: event.importance
+                }))
+            )
+          });
+        } catch (saveErr) {
+          console.error('Failed to save timeline events:', saveErr);
+        }
+      }
+
       // Log new events for debugging
       if (data.newEventsCount > 0) {
         console.log(`✨ Timeline updated: ${data.newEventsCount} new events added`);

--- a/frontend/src/lib/useRealtimeSummary.ts
+++ b/frontend/src/lib/useRealtimeSummary.ts
@@ -123,6 +123,19 @@ export function useRealtimeSummary({
       setSummary(data.summary);
       setLastUpdated(new Date(data.generatedAt));
       setError(null);
+
+      // Persist summary to session if sessionId provided
+      if (sessionId) {
+        try {
+          await fetch(`/api/sessions/${sessionId}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ realtime_summary_cache: data.summary })
+          });
+        } catch (patchErr) {
+          console.error('Failed to update session summary cache:', patchErr);
+        }
+      }
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred';
       setError(errorMessage);


### PR DESCRIPTION
## Summary
- send new transcript lines to the session API when recording
- save refreshed summary to `realtime_summary_cache`
- persist new timeline events to the session

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*