### PR TITLE
Add context support for AI coach

### DIFF
--- a/AI_COACH_CONTEXT_INTEGRATION.md
+++ b/AI_COACH_CONTEXT_INTEGRATION.md
@@ -202,6 +202,24 @@ Comprehensive test suite with 15 test cases covering:
 />
 ```
 
+#### Chat Guidance API Parameters
+
+Send this JSON body to `/api/chat-guidance`:
+
+```json
+{
+  "message": "Your question",
+  "transcript": "full transcript text",
+  "chatHistory": [],
+  "conversationType": "sales",
+  "conversationTitle": "Demo Call",
+  "textContext": "background notes",
+  "sessionId": "abc123"
+}
+```
+
+`textContext` and `conversationTitle` allow the AI Coach to incorporate your setup notes and conversation name when crafting a response.
+
 #### Extending Context Types
 
 To add new conversation types:

--- a/README.md
+++ b/README.md
@@ -49,6 +49,23 @@ Transform how knowledge workers prepare for and conduct critical conversations b
 - **Smart quick-help buttons** that adapt based on conversation type
 - **Contextual message prefixing** to provide AI with relevant background information
 
+The chat guidance endpoint now accepts `textContext` and `conversationTitle` in addition to the transcript and message. Example:
+
+```ts
+await fetch('/api/chat-guidance', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    message: 'What should I ask next?',
+    transcript,
+    chatHistory: [],
+    conversationType: 'sales',
+    conversationTitle: 'Demo Call',
+    textContext: notes,
+  })
+});
+```
+
 ### 📁 Context Management
 - **Multi-file upload** support (PDF, DOC, TXT, MD)
 - **Background notes** for conversation context

--- a/frontend/src/app/app/page-refactored.tsx
+++ b/frontend/src/app/app/page-refactored.tsx
@@ -119,7 +119,13 @@ export default function App() {
     sendMessage: sendChatMessage,
     sendQuickAction,
     markMessagesAsRead
-  } = useChatGuidance();
+  } = useChatGuidance({
+    transcript: transcript.map(line => `${line.speaker}: ${line.text}`).join('\n'),
+    conversationType: config.conversationType,
+    conversationTitle: config.conversationTitle,
+    textContext: config.textContext,
+    sessionId: conversationId
+  });
 
   // Update duration timer
   useEffect(() => {

--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -329,7 +329,9 @@ export default function App() {
   } = useChatGuidance({
     transcript: fullTranscriptText,
     conversationType,
-    sessionId: conversationId || undefined
+    sessionId: conversationId || undefined,
+    conversationTitle,
+    textContext
   });
 
   // Initialize chat guidance when app loads, not just when recording starts

--- a/frontend/src/lib/useChatGuidance.ts
+++ b/frontend/src/lib/useChatGuidance.ts
@@ -26,12 +26,16 @@ interface UseChatGuidanceProps {
   transcript: string;
   conversationType?: string;
   sessionId?: string;
+  textContext?: string;
+  conversationTitle?: string;
 }
 
 export function useChatGuidance({
   transcript,
   conversationType = 'general',
-  sessionId
+  sessionId,
+  textContext,
+  conversationTitle
 }: UseChatGuidanceProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -105,7 +109,9 @@ export function useChatGuidance({
           transcript,
           chatHistory: messages,
           conversationType,
-          sessionId
+          sessionId,
+          textContext,
+          conversationTitle
         })
       });
 
@@ -140,7 +146,7 @@ export function useChatGuidance({
     } finally {
       setIsLoading(false);
     }
-  }, [inputValue, addMessage, transcript, messages, conversationType, sessionId]);
+  }, [inputValue, addMessage, transcript, messages, conversationType, sessionId, textContext, conversationTitle]);
 
   // Quick actions for common requests
   const sendQuickAction = useCallback((action: string) => {


### PR DESCRIPTION
## Summary
- send text context and conversation titles in chat requests
- include text context in API route and prompt builder
- pass context data from pages to the chat hook
- update AI coach docs and README with new API parameters
- extend unit tests for useChatGuidance

## Testing
- `npm test --prefix frontend` *(fails: jest not found)*