### PR TITLE
Bugfix for pause/resume state

### DIFF
--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -297,7 +297,8 @@ export default function App() {
     sessionId: conversationId || undefined,
     conversationType,
     isRecording: conversationState === 'recording',
-    isPaused: conversationState === 'paused',
+    // Treat completed sessions like paused so summary data is retained
+    isPaused: conversationState === 'paused' || conversationState === 'completed',
     refreshIntervalMs: 45000 // 45 seconds
   });
 
@@ -314,7 +315,8 @@ export default function App() {
     sessionId: conversationId || undefined,
     conversationType,
     isRecording: conversationState === 'recording',
-    isPaused: conversationState === 'paused',
+    // Preserve timeline data when session is completed
+    isPaused: conversationState === 'paused' || conversationState === 'completed',
     refreshIntervalMs: 15000 // 15 seconds for real-time timeline
   });
 
@@ -746,6 +748,9 @@ export default function App() {
       await Promise.all([startMyRecording(), startThemRecording()]);
 
       setConversationState('recording');
+      // Reset transcript length trackers for new recording session
+      lastMyTranscriptLen.current = 0;
+      lastTheirTranscriptLen.current = 0;
       setSessionDuration(0);
       if (transcript.length > 0 && conversationState !== 'paused') {
         setTranscript([]);
@@ -821,6 +826,9 @@ export default function App() {
       await Promise.all([startMyRecording(), startThemRecording()]);
 
       setConversationState('recording');
+      // Reset length trackers so new transcript is captured after resume
+      lastMyTranscriptLen.current = 0;
+      lastTheirTranscriptLen.current = 0;
       console.log('✅ Recording resumed and Deepgram reconnected');
     } catch (err) {
       console.error('Failed to resume realtime transcription', err);


### PR DESCRIPTION
## Summary
- preserve summary and timeline when conversation completes
- reset transcript counters on start/resume so transcription works after pausing

## Testing
- `npm --prefix frontend test` *(fails: jest not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of session completion to ensure summary and timeline data are preserved when a conversation is completed.
  - Fixed transcript tracking so that new segments are accurately captured when starting or resuming a recording session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->