### PR TITLE
Fix summary and timeline persistence for loaded sessions

### DIFF
--- a/frontend/src/lib/useIncrementalTimeline.ts
+++ b/frontend/src/lib/useIncrementalTimeline.ts
@@ -201,13 +201,15 @@ export function useIncrementalTimeline({
     };
   }, [isRecording, isPaused, transcript, lastProcessedLength, lastProcessedLineCount, refreshIntervalMs, generateTimelineUpdate]);
 
-  // Clear timeline when not recording or insufficient content
-  // BUT preserve data when paused
+  // Clear timeline only when there isn't enough transcript content.
+  // Previously the hook wiped the timeline whenever recording stopped,
+  // which removed data when restoring a saved session. We now clear
+  // solely based on transcript length so loaded timelines persist.
   useEffect(() => {
     const currentWords = transcript.trim().split(' ').length;
-    
-    // Only clear timeline when truly stopped (not recording AND not paused) or insufficient content (reduced from 30 to 20 words)
-    if ((!isRecording && !isPaused) || currentWords < 20) {
+
+    // Only clear when the transcript is too short (e.g. a new session)
+    if (currentWords < 20) {
       if (timeline.length > 0) {
         setTimeline([]);
         setLastProcessedLength(0);

--- a/frontend/src/lib/useRealtimeSummary.ts
+++ b/frontend/src/lib/useRealtimeSummary.ts
@@ -226,13 +226,16 @@ export function useRealtimeSummary({
     };
   }, [isRecording, isPaused, transcript, refreshIntervalMs, generateSummary]);
 
-  // Set default summary when not recording or insufficient content
-  // BUT preserve data when paused
+  // Set default summary when there isn't enough transcript content
+  // Previously this also cleared when recording stopped which wiped
+  // summaries for loaded sessions. We now only clear when the
+  // transcript itself is short so loaded summaries persist.
   useEffect(() => {
     const currentWords = transcript.trim().split(' ').length;
-    
-    // Only clear summary when truly stopped (not recording AND not paused) or insufficient content
-    if ((!isRecording && !isPaused) || currentWords < 40) {
+
+    // Only clear summary when there is not enough transcript content
+    // (e.g. a new session with an empty transcript)
+    if (currentWords < 40) {
       const defaultSummary: ConversationSummary = {
         tldr: 'Not enough conversation content to generate a meaningful summary yet.',
         keyPoints: [],


### PR DESCRIPTION
## Summary
- keep summary data when recording stops and transcript is long enough
- keep timeline data when recording stops and transcript is long enough

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*