### PR TITLE
Fix word count detection for summary and timeline

### DIFF
--- a/frontend/src/lib/useIncrementalTimeline.ts
+++ b/frontend/src/lib/useIncrementalTimeline.ts
@@ -49,7 +49,7 @@ export function useIncrementalTimeline({
 
   const generateTimelineUpdate = useCallback(async (force: boolean = false) => {
     const transcriptLines = transcript.split('\n').filter(line => line.trim().length > 0);
-    const transcriptWords = transcript.trim().split(' ').length;
+    const transcriptWords = transcript.trim().split(/\s+/).filter(Boolean).length;
     
     // Only log when actually generating or when there's an issue
     if (force || (isRecording && !isPaused)) {
@@ -181,7 +181,7 @@ export function useIncrementalTimeline({
 
     // Only set up auto-refresh if recording and have sufficient transcript
     // Don't auto-refresh when paused, but preserve existing data
-    if (isRecording && !isPaused && transcript && transcript.trim().split(' ').length >= 20) {
+    if (isRecording && !isPaused && transcript && transcript.trim().split(/\s+/).filter(Boolean).length >= 20) {
       refreshIntervalRef.current = setInterval(() => {
         const transcriptLines = transcript.split('\n').filter(line => line.trim().length > 0);
         const newLinesSinceLastUpdate = transcriptLines.length - lastProcessedLineCount;
@@ -206,7 +206,7 @@ export function useIncrementalTimeline({
   // which removed data when restoring a saved session. We now clear
   // solely based on transcript length so loaded timelines persist.
   useEffect(() => {
-    const currentWords = transcript.trim().split(' ').length;
+    const currentWords = transcript.trim().split(/\s+/).filter(Boolean).length;
 
     // Only clear when the transcript is too short (e.g. a new session)
     if (currentWords < 20) {
@@ -221,7 +221,7 @@ export function useIncrementalTimeline({
 
   // Generate initial timeline when recording starts with sufficient content
   useEffect(() => {
-    const currentWords = transcript.trim().split(' ').length;
+    const currentWords = transcript.trim().split(/\s+/).filter(Boolean).length;
     
     if (isRecording && !isPaused && currentWords >= 20 && !initialTimelineGenerated.current && !isLoading) {
       initialTimelineGenerated.current = true;

--- a/frontend/src/lib/useRealtimeSummary.ts
+++ b/frontend/src/lib/useRealtimeSummary.ts
@@ -58,7 +58,7 @@ export function useRealtimeSummary({
 
   const generateSummary = useCallback(async (force: boolean = false) => {
     const transcriptLines = transcript.split('\n').filter(line => line.trim().length > 0);
-    const transcriptWords = transcript.trim().split(' ').length;
+    const transcriptWords = transcript.trim().split(/\s+/).filter(Boolean).length;
     
     // Only log when actually generating or when there's an issue
     if (force || (isRecording && !isPaused)) {
@@ -204,10 +204,10 @@ export function useRealtimeSummary({
 
     // Only set up auto-refresh if recording and have sufficient transcript
     // Don't auto-refresh when paused, but preserve existing data
-    if (isRecording && !isPaused && transcript && transcript.trim().split(' ').length >= 40) {
+    if (isRecording && !isPaused && transcript && transcript.trim().split(/\s+/).filter(Boolean).length >= 40) {
       refreshIntervalRef.current = setInterval(() => {
         const transcriptLines = transcript.split('\n').filter(line => line.trim().length > 0);
-        const transcriptWords = transcript.trim().split(' ').length;
+        const transcriptWords = transcript.trim().split(/\s+/).filter(Boolean).length;
         const newLinesSinceLastUpdate = transcriptLines.length - lastTranscriptLineCount.current;
         const newWordsSinceLastUpdate = transcriptWords - lastTranscriptLength.current;
         
@@ -231,7 +231,7 @@ export function useRealtimeSummary({
   // summaries for loaded sessions. We now only clear when the
   // transcript itself is short so loaded summaries persist.
   useEffect(() => {
-    const currentWords = transcript.trim().split(' ').length;
+    const currentWords = transcript.trim().split(/\s+/).filter(Boolean).length;
 
     // Only clear summary when there is not enough transcript content
     // (e.g. a new session with an empty transcript)
@@ -262,7 +262,7 @@ export function useRealtimeSummary({
 
   // Generate initial summary when recording starts with sufficient content
   useEffect(() => {
-    const currentWords = transcript.trim().split(' ').length;
+    const currentWords = transcript.trim().split(/\s+/).filter(Boolean).length;
     
     if (isRecording && !isPaused && currentWords >= 40 && !initialSummaryGenerated.current && !isLoading) {
       initialSummaryGenerated.current = true;


### PR DESCRIPTION
## Summary
- handle whitespace properly when counting words for summary and timeline generation

## Testing
- `npm test --prefix frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683aa8d71d108329a49157823cf59799