### PR TITLE
Fix guidance API param for Gemini

### DIFF
--- a/frontend/src/app/app/page-refactored.tsx
+++ b/frontend/src/app/app/page-refactored.tsx
@@ -291,7 +291,7 @@ export default function App() {
     const request: GuidanceRequest = {
       conversationType: config.conversationType,
       transcript: transcript.map(line => line.text).join('\n'),
-      context: contextDocuments,
+      textContext: contextDocuments,
       previousGuidance: currentGuidance || []
     };
 

--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -1570,7 +1570,7 @@ export default function App() {
       
       const guidanceRequest: GuidanceRequest = {
         transcript: recentTranscript,
-        context: textContext,
+        textContext: textContext,
         conversationType: conversationType,
       };
 

--- a/frontend/src/lib/aiGuidance.ts
+++ b/frontend/src/lib/aiGuidance.ts
@@ -9,7 +9,7 @@ import { config } from './config';
 
 export interface GuidanceRequest {
   transcript: string;
-  context: string;
+  textContext: string;
   userContext?: string;
   conversationType?: 'sales' | 'support' | 'meeting' | 'interview';
   participantRole?: 'host' | 'participant' | 'interviewer' | 'interviewee';
@@ -95,7 +95,7 @@ export class AIGuidanceEngine {
         },
         body: JSON.stringify({
           transcript: request.transcript,
-          context: contextSummary,
+          textContext: contextSummary,
           userContext: request.userContext,
           conversationType: request.conversationType,
           participantRole: request.participantRole

--- a/frontend/tests/api/guidance.test.ts
+++ b/frontend/tests/api/guidance.test.ts
@@ -41,7 +41,7 @@ describe('OpenRouter Guidance API Logic', () => {
 
       const requestData = {
         transcript: 'Hello, I am interested in your product.',
-        context: 'Sales call with potential customer',
+        textContext: 'Sales call with potential customer',
         userContext: 'First-time buyer, budget conscious',
         conversationType: 'sales',
         participantRole: 'host'

--- a/frontend/tests/lib/aiGuidance.test.ts
+++ b/frontend/tests/lib/aiGuidance.test.ts
@@ -45,7 +45,7 @@ describe('AI Guidance Engine', () => {
 
       const request: GuidanceRequest = {
         transcript: 'Customer: I am interested in your product but need to understand pricing.',
-        context: 'Sales call with enterprise client',
+        textContext: 'Sales call with enterprise client',
         userContext: 'High-value prospect, budget conscious',
         conversationType: 'sales',
         participantRole: 'host'
@@ -70,7 +70,7 @@ describe('AI Guidance Engine', () => {
         },
         body: JSON.stringify({
           transcript: request.transcript,
-          context: 'No context documents provided',
+          textContext: 'No context documents provided',
           userContext: request.userContext,
           conversationType: request.conversationType,
           participantRole: request.participantRole
@@ -88,7 +88,7 @@ describe('AI Guidance Engine', () => {
 
       const request: GuidanceRequest = {
         transcript: 'Test transcript',
-        context: 'Test context',
+        textContext: 'Test context',
       }
 
       const result = await guidanceEngine.generateGuidance(request)
@@ -104,7 +104,7 @@ describe('AI Guidance Engine', () => {
 
       const request: GuidanceRequest = {
         transcript: 'Test transcript',
-        context: 'Test context',
+        textContext: 'Test context',
       }
 
       const result = await guidanceEngine.generateGuidance(request)
@@ -122,7 +122,7 @@ describe('AI Guidance Engine', () => {
 
       const request: GuidanceRequest = {
         transcript: 'Customer is asking about features',
-        context: '', // Empty context
+        textContext: '', // Empty context
       }
 
       const result = await guidanceEngine.generateGuidance(request)
@@ -135,7 +135,7 @@ describe('AI Guidance Engine', () => {
         },
         body: JSON.stringify({
           transcript: request.transcript,
-          context: 'No context documents provided',
+          textContext: 'No context documents provided',
           userContext: request.userContext,
           conversationType: request.conversationType,
           participantRole: request.participantRole
@@ -161,7 +161,7 @@ describe('AI Guidance Engine', () => {
 
       const request: GuidanceRequest = {
         transcript: 'Customer: My login is not working',
-        context: 'Support ticket',
+        textContext: 'Support ticket',
         conversationType: 'support',
         participantRole: 'host' // Fixed: use valid role
       }
@@ -189,7 +189,7 @@ describe('AI Guidance Engine', () => {
 
       const request: GuidanceRequest = {
         transcript: 'Test transcript',
-        context: 'Test context',
+        textContext: 'Test context',
       }
 
       const result = await guidanceEngine.generateGuidance(request)
@@ -208,7 +208,7 @@ describe('AI Guidance Engine', () => {
 
       const request: GuidanceRequest = {
         transcript: 'Test transcript',
-        context: 'Test context',
+        textContext: 'Test context',
       }
 
       const result = await guidanceEngine.generateGuidance(request)
@@ -224,7 +224,7 @@ describe('AI Guidance Engine', () => {
 
       const request: GuidanceRequest = {
         transcript: 'Full conversation transcript',
-        context: 'Meeting context',
+        textContext: 'Meeting context',
         userContext: 'User-provided context',
         conversationType: 'meeting',
         participantRole: 'host' // Fixed: use valid role
@@ -239,7 +239,7 @@ describe('AI Guidance Engine', () => {
         },
         body: JSON.stringify({
           transcript: 'Full conversation transcript',
-          context: 'No context documents provided',
+          textContext: 'No context documents provided',
           userContext: 'User-provided context',
           conversationType: 'meeting',
           participantRole: 'host'


### PR DESCRIPTION
## Summary
- update `GuidanceRequest` to use `textContext`
- send `textContext` to guidance API
- align app page and refactored page
- update tests for new property

## Testing
- `npm test` *(fails: Jest encountered errors)*

------
https://chatgpt.com/codex/tasks/task_e_683f49cbe62c832992ef2c9aa9b23daa