### PR TITLE
Add chat history to prompt

### DIFF
--- a/frontend/src/app/api/chat-guidance/route.ts
+++ b/frontend/src/app/api/chat-guidance/route.ts
@@ -270,7 +270,7 @@ PREVIOUS CONVERSATION CONTEXT:
 - Provide continuity by acknowledging past interactions and progress`;
 }
 
-function buildChatPrompt(message: string, transcript: string, chatHistory: ChatMessage[], conversationType?: string, conversationTitle?: string, textContext?: string, summary?: any, timeline?: any[], uploadedFiles?: Array<{ name: string; type: string; size: number }>, selectedPreviousConversations?: string[], personalContext?: string): string {
+export function buildChatPrompt(message: string, transcript: string, chatHistory: ChatMessage[], conversationType?: string, conversationTitle?: string, textContext?: string, summary?: any, timeline?: any[], uploadedFiles?: Array<{ name: string; type: string; size: number }>, selectedPreviousConversations?: string[], personalContext?: string): string {
   // Detect if user is in live conversation or preparation mode
   const hasActiveTranscript = transcript && transcript.trim().length > 0;
   const isLiveConversation = hasActiveTranscript || message.toLowerCase().includes('they') || message.toLowerCase().includes('currently') || message.toLowerCase().includes('right now');
@@ -343,7 +343,16 @@ function buildChatPrompt(message: string, transcript: string, chatHistory: ChatM
   } else {
     prompt += `No live transcript available yet.\n\n`;
   }
-  
+
+  // Recent chat history
+  if (chatHistory && chatHistory.length > 0) {
+    const history = chatHistory
+      .slice(-6)
+      .map(m => `${m.type === 'user' ? 'User' : 'AI'}: ${m.content}`)
+      .join('\n');
+    prompt += `CHAT HISTORY:\n${history}\n\n`;
+  }
+
   prompt += `USER QUESTION: ${message}\n\n`;
   prompt += `Please provide specific, actionable guidance based on the conversation context above. If this is about sales and the user asks "What am I selling?", use the background notes and context to explain their specific product/service. Be contextual and helpful.`;
   

--- a/frontend/tests/lib/useChatGuidance.test.ts
+++ b/frontend/tests/lib/useChatGuidance.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { useChatGuidance } from '@/lib/useChatGuidance';
+import { buildChatPrompt } from '@/app/api/chat-guidance/route';
 
 // Mock fetch for API calls
 global.fetch = jest.fn();
@@ -149,5 +150,27 @@ describe('useChatGuidance', () => {
         conversationTitle: 'Demo'
       })
     }));
+  });
+
+  it('buildChatPrompt should include recent chat history', () => {
+    const history = Array.from({ length: 7 }).map((_, i) => ({
+      id: `id${i}`,
+      type: i % 2 === 0 ? 'user' as const : 'ai' as const,
+      content: `message ${i}`,
+      timestamp: new Date()
+    }));
+
+    const prompt = buildChatPrompt(
+      'final question',
+      '',
+      history,
+      'sales',
+      'Demo Chat'
+    );
+
+    expect(prompt).toContain('CHAT HISTORY');
+    expect(prompt).toContain('User: message 1');
+    expect(prompt).toContain('AI: message 6');
+    expect(prompt).not.toContain('message 0');
   });
 });


### PR DESCRIPTION
## Summary
- expose `buildChatPrompt` and include last six messages of chat history
- test the new helper in `useChatGuidance` tests

## Testing
- `npm test --silent` *(fails: Unable to transform ESM modules and several test failures)*

------
https://chatgpt.com/codex/tasks/task_e_684011a0c1248329bd9a8d7cd5225f2a