### PR TITLE
Summarize long chat history before sending prompt

### DIFF
--- a/frontend/tests/api/chatPrompt.test.ts
+++ b/frontend/tests/api/chatPrompt.test.ts
@@ -1,0 +1,34 @@
+import { buildChatPrompt } from '@/app/api/chat-guidance/route';
+
+describe('buildChatPrompt', () => {
+  const baseMessage = 'What next?';
+
+  it('includes all messages verbatim when history is short', () => {
+    const history = [
+      { id: '1', type: 'user', content: 'Hello', timestamp: new Date() },
+      { id: '2', type: 'ai', content: 'Hi there', timestamp: new Date() }
+    ] as any;
+
+    const prompt = buildChatPrompt(baseMessage, '', history);
+
+    expect(prompt).toContain('CHAT HISTORY:');
+    expect(prompt).toContain('User: Hello');
+    expect(prompt).toContain('AI: Hi there');
+  });
+
+  it('summarises older messages when history is long', () => {
+    const longHistory = Array.from({ length: 8 }).map((_, i) => ({
+      id: `${i}`,
+      type: i % 2 === 0 ? 'user' : 'ai',
+      content: `msg${i + 1}`,
+      timestamp: new Date()
+    })) as any;
+
+    const prompt = buildChatPrompt(baseMessage, '', longHistory);
+
+    expect(prompt).toContain('PREVIOUS CHAT SUMMARY');
+    expect(prompt).toContain('- User: msg1');
+    expect(prompt).toContain('RECENT CHAT MESSAGES');
+    expect(prompt).toContain('AI: msg8');
+  });
+});


### PR DESCRIPTION
## Summary
- condense long chat history in `buildChatPrompt`
- export helper to aid testing
- add new tests covering short and long history cases

## Testing
- `npm test --silent` *(fails: Jest cannot parse certain dependencies)*
- `npx jest tests/api/chatPrompt.test.ts --runTestsByPath --silent`

------
https://chatgpt.com/codex/tasks/task_e_684011a484f08329b54e5b0acaaa665a