### PR TITLE
Implement basic speaker detection

### DIFF
--- a/frontend/src/components/conversation/ConversationContentEnhanced.tsx
+++ b/frontend/src/components/conversation/ConversationContentEnhanced.tsx
@@ -39,7 +39,7 @@ interface ConversationContentEnhancedProps {
   setRecordingDuration: (duration: number) => void;
   
   // Transcription handler
-  onTranscriptionUpdate: (text: string, isFinal: boolean) => void;
+  onTranscriptionUpdate: (text: string, isFinal: boolean, speaker?: string) => void;
   
   // Active tab
   activeTab?: 'summary' | 'timeline' | 'checklist';
@@ -340,9 +340,7 @@ export const ConversationContentEnhanced: React.FC<ConversationContentEnhancedPr
 
       {/* Hidden audio capture component */}
       <RealtimeAudioCapture
-        isRecording={isRecording}
-        onTranscriptionUpdate={onTranscriptionUpdate}
-        sessionId={sessionId}
+        onTranscript={(text, speaker) => onTranscriptionUpdate(text, true, speaker)}
       />
     </div>
   );

--- a/frontend/src/components/conversation/ConversationView.tsx
+++ b/frontend/src/components/conversation/ConversationView.tsx
@@ -5,7 +5,6 @@ import { motion } from 'framer-motion';
 import { ConversationContentEnhanced } from '@/components/conversation/ConversationContentEnhanced';
 import { TranscriptSidebar } from '@/components/conversation/TranscriptSidebar';
 import { useTranscriptManager } from '@/lib/hooks/useTranscriptManager';
-import { useTranscription } from '@/lib/useTranscription';
 import { Card } from '@/components/ui/Card';
 import { cn } from '@/lib/utils';
 
@@ -41,11 +40,15 @@ export function ConversationView({
   });
 
   // Set up transcription handler
-  const onTranscriptionUpdate = (text: string, isFinal: boolean) => {
+  const onTranscriptionUpdate = (text: string, isFinal: boolean, speaker?: string) => {
     if (text.trim()) {
+      const normalized = speaker?.toLowerCase().includes('1') ? 'me'
+        : speaker?.toLowerCase().includes('2') ? 'them'
+        : 'user';
+
       addTranscript({
         content: text,
-        speaker: 'user', // TODO: Detect speaker
+        speaker: normalized,
         confidence_score: isFinal ? 1.0 : 0.8,
         start_time_seconds: recordingDuration,
         is_final: isFinal
@@ -59,7 +62,7 @@ export function ConversationView({
       id: t.id,
       text: t.content,
       timestamp: new Date(Date.now() - (recordingDuration - t.start_time_seconds) * 1000),
-      speaker: t.speaker === 'user' ? 'ME' : 'THEM',
+      speaker: ['user', 'me'].includes(t.speaker.toLowerCase()) ? 'ME' : 'THEM',
       confidence: t.confidence_score
     }));
     


### PR DESCRIPTION
## Summary
- add `speaker` argument to `onTranscriptionUpdate`
- map speakers from RealtimeAudioCapture into transcript updates
- normalize speaker labels and display correctly in ConversationView

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840496695348329855f6999dac3bae8