### PR TITLE
Fix TypeScript errors across frontend

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1340,16 +1340,17 @@ const DashboardPage: React.FC = () => {
           metadata: {
             conversation_type: config.conversationType,
             created_from: 'dashboard',
-            has_files: config.context?.files?.length > 0
+            has_files: !!(config.context?.files && config.context.files.length > 0)
           }
         } : undefined
       });
       
       if (newSession) {
         // Upload files if any were provided
-        if (config.context?.files && config.context.files.length > 0) {
+        const files = config.context?.files;
+        if (files && files.length > 0) {
           try {
-            await uploadDocuments(newSession.id, config.context.files);
+            await uploadDocuments(newSession.id, files);
             console.log('✅ Files uploaded successfully for session:', newSession.id);
           } catch (error) {
             console.error('❌ Failed to upload files:', error);

--- a/frontend/src/app/demo/page.tsx
+++ b/frontend/src/app/demo/page.tsx
@@ -83,7 +83,7 @@ export default function DemoPage() {
               <div>
                 <h3 className="font-semibold mb-3">Variants</h3>
                 <div className="flex flex-wrap gap-2">
-                  <Button variant="default">Default</Button>
+                  <Button variant="primary">Default</Button>
                   <Button variant="secondary">Secondary</Button>
                   <Button variant="outline">Outline</Button>
                   <Button variant="ghost">Ghost</Button>

--- a/frontend/src/app/pricing/page.tsx
+++ b/frontend/src/app/pricing/page.tsx
@@ -437,7 +437,7 @@ export default function PricingPage() {
                         ? 'bg-gradient-to-r from-primary to-primary/90 hover:from-primary/90 hover:to-primary shadow-lg hover:shadow-xl hover:-translate-y-0.5' 
                         : 'hover:shadow-md hover:-translate-y-0.5'
                     }`}
-                    variant={plan.display.isFeatured ? 'default' : 'outline'}
+                    variant={plan.display.isFeatured ? 'primary' : 'outline'}
                     disabled={currentUserPlan === plan.slug}
                   >
                     {currentUserPlan === plan.slug ? 'Current Plan' :

--- a/frontend/src/app/summary/[id]/page.tsx
+++ b/frontend/src/app/summary/[id]/page.tsx
@@ -1180,10 +1180,11 @@ const ExportModal: React.FC<{
             textContent += '\n';
           }
           
-          if (sessionData.summary.insights?.length > 0) {
+          const insights = sessionData.summary.insights;
+          if (insights && insights.length > 0) {
             textContent += `KEY INSIGHTS\n`;
             textContent += `------------\n`;
-            sessionData.summary.insights.forEach((insight, idx) => {
+            insights.forEach((insight, idx) => {
               if (typeof insight === 'string') {
                 textContent += `${idx + 1}. ${insight}\n`;
               } else if (insight.observation) {
@@ -1196,28 +1197,31 @@ const ExportModal: React.FC<{
             textContent += '\n';
           }
           
-          if (sessionData.summary.followUpQuestions?.length > 0) {
+          const followUps = sessionData.summary.followUpQuestions;
+          if (followUps && followUps.length > 0) {
             textContent += `FOLLOW-UP QUESTIONS\n`;
             textContent += `------------------\n`;
-            sessionData.summary.followUpQuestions?.forEach((question, idx) => {
+            followUps.forEach((question, idx) => {
               textContent += `${idx + 1}. ${question}\n`;
             });
             textContent += '\n';
           }
           
-          if (sessionData.summary.successfulMoments?.length > 0) {
+          const successful = sessionData.summary.successfulMoments;
+          if (successful && successful.length > 0) {
             textContent += `SUCCESSFUL MOMENTS\n`;
             textContent += `-----------------\n`;
-            sessionData.summary.successfulMoments?.forEach((moment, idx) => {
+            successful.forEach((moment, idx) => {
               textContent += `${idx + 1}. ${moment}\n`;
             });
             textContent += '\n';
           }
           
-          if (sessionData.summary.coachingRecommendations?.length > 0) {
+          const coaching = sessionData.summary.coachingRecommendations;
+          if (coaching && coaching.length > 0) {
             textContent += `COACHING RECOMMENDATIONS\n`;
             textContent += `-----------------------\n`;
-            sessionData.summary.coachingRecommendations?.forEach((rec, idx) => {
+            coaching.forEach((rec, idx) => {
               textContent += `${idx + 1}. ${rec}\n`;
             });
             textContent += '\n';

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -229,8 +229,8 @@ export interface SummaryResponse {
 
 export interface SummaryInsight {
   observation: string;
-  evidence: string;
-  recommendation: string;
+  evidence?: string;
+  recommendation?: string;
 }
 
 export interface SummaryActionItem {

--- a/frontend/src/types/app.ts
+++ b/frontend/src/types/app.ts
@@ -10,14 +10,14 @@ export interface TranscriptLine {
 }
 
 export interface ConversationSummary {
-  tldr?: string;
-  keyPoints?: string[];
-  actionItems?: string[];
-  decisions?: string[];
-  nextSteps?: string[];
-  topics?: string[];
-  sentiment?: 'positive' | 'negative' | 'neutral';
-  progressStatus?: 'just_started' | 'building_momentum' | 'making_progress' | 'wrapping_up';
+  tldr: string;
+  keyPoints: string[];
+  actionItems: string[];
+  decisions: string[];
+  nextSteps: string[];
+  topics: string[];
+  sentiment: 'positive' | 'negative' | 'neutral';
+  progressStatus: 'just_started' | 'building_momentum' | 'making_progress' | 'wrapping_up';
 }
 
 export interface SessionFile {


### PR DESCRIPTION
## Summary
- adjust ConversationSummary types to be strict
- make SummaryInsight fields optional
- handle optional files list in dashboard page
- fix button variants in demo and pricing pages
- guard optional summary arrays when generating export text

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: TestingLibraryElementError etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68445056dc7483299ce2f8015bee9221