### PR TITLE
Use shared conversation types

### DIFF
--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -45,6 +45,7 @@ import { useMinuteTracking } from '@/lib/hooks/useMinuteTracking';
 import { RecordingConsentModal } from '@/components/conversation/RecordingConsentModal';
 import { LoadingModal } from '@/components/ui/LoadingModal';
 import type { SessionDataFull, ConversationSummary as ConversationSummaryType, TranscriptData, SessionFile } from '@/types/app';
+import type { TranscriptLine, ConversationState } from '@/types/conversation';
 
 // Type assertion for getDisplayMedia support
 declare global {
@@ -52,16 +53,6 @@ declare global {
     getDisplayMedia(constraints?: { audio?: boolean | MediaTrackConstraints; video?: boolean | MediaTrackConstraints }): Promise<MediaStream>;
   }
 }
-
-interface TranscriptLine {
-  id: string;
-  text: string;
-  timestamp: Date;
-  speaker: 'ME' | 'THEM';
-  confidence?: number;
-}
-
-type ConversationState = 'setup' | 'ready' | 'recording' | 'paused' | 'processing' | 'completed' | 'error';
 
 type ConversationSummary = ConversationSummaryType;
 


### PR DESCRIPTION
## Summary
- import `TranscriptLine` and `ConversationState` from shared types
- remove duplicate type definitions in `app/page.tsx`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847d66933388329adccaed1bb133d26