### PR TITLE
Centralize conversation type mapping

### DIFF
--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -73,6 +73,7 @@ import { RecordingConsentModal } from '@/components/conversation/RecordingConsen
 import { ConversationHeaderDate } from '@/components/ui/ConversationDateIndicator';
 import { LoadingModal } from '@/components/ui/LoadingModal';
 import type { SessionDataFull, ConversationSummary as ConversationSummaryType, TranscriptData, LocalStorageData, SessionFile } from '@/types/app';
+import { conversationTypeMap } from '@/lib/conversation/conversationTypeMap';
 
 // Type assertion for getDisplayMedia support
 declare global {
@@ -434,14 +435,8 @@ function AppContent() {
         setConversationTitle(sessionData.title || 'Untitled Conversation');
         
         // Map conversation type from database format to app format
-        const dbTypeMapping: Record<string, 'sales' | 'support' | 'meeting' | 'interview'> = {
-          'sales_call': 'sales',
-          'support_call': 'support',
-          'meeting': 'meeting',
-          'interview': 'interview',
-          'consultation': 'meeting'
-        };
-        const mappedType = dbTypeMapping[sessionData.conversation_type] || 'sales';
+        const mappedType =
+          conversationTypeMap[sessionData.conversation_type] || 'sales';
         console.log('🔍 Session Type Mapping:', {
           dbType: sessionData.conversation_type,
           mappedType: mappedType
@@ -1134,25 +1129,7 @@ function AppContent() {
           setConversationTitle(config.title || 'New Conversation');
           
           // Map conversation type from dashboard format to app format
-          const typeMapping: Record<string, 'sales' | 'support' | 'meeting' | 'interview'> = {
-            'sales_call': 'sales',
-            'Sales Call': 'sales',
-            'Product Demo': 'sales',
-            'support_call': 'support',
-            'Support Call': 'support',
-            'Customer Support Call': 'support',
-            'meeting': 'meeting',
-            'Meeting': 'meeting',
-            'Team Standup Meeting': 'meeting',
-            'Project Meeting': 'meeting',
-            'interview': 'interview',
-            'Interview': 'interview',
-            'consultation': 'meeting',
-            'Consultation': 'meeting',
-            'Business Review': 'meeting'
-          };
-          
-          const mappedType = typeMapping[config.type] || 'sales';
+          const mappedType = conversationTypeMap[config.type] || 'sales';
           setConversationType(mappedType);
           
           // Load selected previous conversations if provided
@@ -1248,24 +1225,8 @@ function AppContent() {
           }
           
           if (sessionData.conversation_type) {
-            const typeMapping: Record<string, 'sales' | 'support' | 'meeting' | 'interview'> = {
-              'sales_call': 'sales',
-              'Sales Call': 'sales',
-              'Product Demo': 'sales',
-              'support_call': 'support',
-              'Support Call': 'support',
-              'Customer Support Call': 'support',
-              'meeting': 'meeting',
-              'Meeting': 'meeting',
-              'Team Standup Meeting': 'meeting',
-              'Project Meeting': 'meeting',
-              'interview': 'interview',
-              'Interview': 'interview',
-              'consultation': 'meeting',
-              'Consultation': 'meeting',
-              'Business Review': 'meeting'
-            };
-            const mappedType = typeMapping[sessionData.conversation_type] || 'sales';
+            const mappedType =
+              conversationTypeMap[sessionData.conversation_type] || 'sales';
             setConversationType(mappedType as 'sales' | 'support' | 'meeting' | 'interview');
           }
           

--- a/frontend/src/lib/conversation/conversationTypeMap.ts
+++ b/frontend/src/lib/conversation/conversationTypeMap.ts
@@ -1,0 +1,19 @@
+import type { ConversationType } from '@/types/conversation';
+
+export const conversationTypeMap: Record<string, ConversationType> = {
+  'sales_call': 'sales',
+  'Sales Call': 'sales',
+  'Product Demo': 'sales',
+  'support_call': 'support',
+  'Support Call': 'support',
+  'Customer Support Call': 'support',
+  'meeting': 'meeting',
+  'Meeting': 'meeting',
+  'Team Standup Meeting': 'meeting',
+  'Project Meeting': 'meeting',
+  'interview': 'interview',
+  'Interview': 'interview',
+  'consultation': 'meeting',
+  'Consultation': 'meeting',
+  'Business Review': 'meeting'
+};


### PR DESCRIPTION
## Summary
- add `conversationTypeMap` constant under `lib/conversation`
- replace inline objects in `app/page.tsx` with the shared map

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847fa3af4788329a4c5eb6ccda3421b