### PR TITLE
Refactor ServiceFactory to use instance methods

### DIFF
--- a/frontend/src/services/ServiceFactory.ts
+++ b/frontend/src/services/ServiceFactory.ts
@@ -31,36 +31,40 @@ export class ServiceFactory {
     return ServiceFactory.instance;
   }
   
-  static getTranscriptService(): TranscriptService {
-    return ServiceFactory.getInstance().transcriptService;
+  getTranscriptService(): TranscriptService {
+    return this.transcriptService;
   }
   
-  static getSessionService(): SessionService {
-    return ServiceFactory.getInstance().sessionService;
+  getSessionService(): SessionService {
+    return this.sessionService;
   }
   
-  static getContextService(): ContextService {
-    return ServiceFactory.getInstance().contextService;
+  getContextService(): ContextService {
+    return this.contextService;
   }
   
-  static getSummaryService(): SummaryService {
-    return ServiceFactory.getInstance().summaryService;
+  getSummaryService(): SummaryService {
+    return this.summaryService;
   }
   
-  static getChecklistService(): ChecklistService {
-    return ServiceFactory.getInstance().checklistService;
+  getChecklistService(): ChecklistService {
+    return this.checklistService;
   }
   
-  static getRecordingService(): RecordingService {
-    return ServiceFactory.getInstance().recordingService;
+  getRecordingService(): RecordingService {
+    return this.recordingService;
   }
-
-export const services = ServiceFactory.getInstance();
 
 // Convenience exports
-export const transcriptService = services.getTranscriptService();
-export const sessionService = services.getSessionService();
-export const contextService = services.getContextService();
-export const summaryService = services.getSummaryService();
-export const checklistService = services.getChecklistService();
-export const recordingService = services.getRecordingService();
+export const transcriptService =
+  ServiceFactory.getInstance().getTranscriptService();
+export const sessionService =
+  ServiceFactory.getInstance().getSessionService();
+export const contextService =
+  ServiceFactory.getInstance().getContextService();
+export const summaryService =
+  ServiceFactory.getInstance().getSummaryService();
+export const checklistService =
+  ServiceFactory.getInstance().getChecklistService();
+export const recordingService =
+  ServiceFactory.getInstance().getRecordingService();

--- a/frontend/tests/hooks/conversation/useFullSessionManagement.test.ts
+++ b/frontend/tests/hooks/conversation/useFullSessionManagement.test.ts
@@ -35,14 +35,18 @@ jest.mock('@/hooks/conversation/useSessionList', () => ({
   })),
 }));
 
+const getSessionServiceMock = jest.fn(() => ({
+  finalizeSession: jest.fn().mockResolvedValue({
+    success: true,
+    sessionId: 'session-123',
+    summary: { tldr: 'Test summary' },
+  }),
+}));
+
 jest.mock('@/services/ServiceFactory', () => ({
   ServiceFactory: {
-    getSessionService: jest.fn(() => ({
-      finalizeSession: jest.fn().mockResolvedValue({
-        success: true,
-        sessionId: 'session-123',
-        summary: { tldr: 'Test summary' },
-      }),
+    getInstance: jest.fn(() => ({
+      getSessionService: getSessionServiceMock,
     })),
   },
 }));
@@ -167,8 +171,9 @@ describe('useFullSessionManagement', () => {
       });
     });
 
-    expect(jest.requireMock('@/services/ServiceFactory').ServiceFactory.getSessionService)
-      .toHaveBeenCalled();
+    const factoryMock = jest.requireMock('@/services/ServiceFactory').ServiceFactory;
+    expect(factoryMock.getInstance).toHaveBeenCalled();
+    expect(getSessionServiceMock).toHaveBeenCalled();
   });
 
   it('should load sessions on mount', async () => {


### PR DESCRIPTION
## Summary
- refactor ServiceFactory so service getters are instance methods
- update convenience exports to call the new instance methods
- adjust useFullSessionManagement test mocks for new API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684812c413208329bf898688885fec2a